### PR TITLE
Add result propagation in TransactionUnitOfWork.complete

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unit-of-work",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Unit of Work pattern is used to group one or more operations (usually database operations) into a single transaction or “unit of work”, so that all operations either pass or fail as one. This utility is implemented in Typescript",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/providers/sequelize/sequelize-uow.ts
+++ b/src/providers/sequelize/sequelize-uow.ts
@@ -5,7 +5,7 @@ export class SequelizeUnitOfWork implements TransactionUnitOfWork {
   start(): Promise<void> {
     throw new Error('Method not implemented.');
   }
-  complete(work: () => void): Promise<void> {
+  complete<T>(work: () => T | Promise<T>): Promise<T> {
     throw new Error('Method not implemented.');
   }
   registerRepository(repositry: any) {

--- a/src/providers/transaction-uow.interface.ts
+++ b/src/providers/transaction-uow.interface.ts
@@ -1,6 +1,6 @@
 export interface TransactionUnitOfWork {
   start(): Promise<void>;
-  complete(work: () => void): Promise<void>;
+  complete<T>(work: () => T | Promise<T>): Promise<T>;
   registerRepository(repositry);
   registerCustomRepository(customRepository);
 }

--- a/src/providers/typeorm/typeorm-uow.ts
+++ b/src/providers/typeorm/typeorm-uow.ts
@@ -53,10 +53,11 @@ export class TypeOrmUnitOfWork implements TransactionUnitOfWork {
     return this.transactionManager.getCustomRepository(customRepository);
   }
 
-  async complete(work: () => void): Promise<void> {
+  async complete<T>(work: () => T | Promise<T>): Promise<T> {
     try {
-      await work();
+      const result = await work();
       await this.queryRunner.commitTransaction();
+      return result;
     } catch (error) {
       await this.queryRunner.rollbackTransaction();
       console.error(error); // TODO: Logging can be better


### PR DESCRIPTION
Thought it would be nice to be able to pass the results of work through.